### PR TITLE
Restore data sources

### DIFF
--- a/do-backup.go
+++ b/do-backup.go
@@ -150,7 +150,7 @@ func backupDatasources(cmd *command, datasources map[string]bool) {
 				fmt.Fprintf(os.Stderr, "datasource marshal error %s\n", err)
 				continue
 			}
-			var fname = fmt.Sprintf("%s-%d.ds.json", slug.Make(ds.Name), ds.OrgID)
+			var fname = fmt.Sprintf("%s.ds.%d.json", slug.Make(ds.Name), ds.OrgID)
 			if err = ioutil.WriteFile(fname, rawDs, os.FileMode(int(0666))); err != nil {
 				fmt.Fprintf(os.Stderr, fmt.Sprintf("%s for %s\n", err, ds.Name))
 				continue

--- a/do-backup.go
+++ b/do-backup.go
@@ -150,7 +150,7 @@ func backupDatasources(cmd *command, datasources map[string]bool) {
 				fmt.Fprintf(os.Stderr, "datasource marshal error %s\n", err)
 				continue
 			}
-			var fname = fmt.Sprintf("%s.ds.%d.json", slug.Make(ds.Name), ds.OrgID)
+			var fname = fmt.Sprintf("%s-%d.ds.json", slug.Make(ds.Name), ds.OrgID)
 			if err = ioutil.WriteFile(fname, rawDs, os.FileMode(int(0666))); err != nil {
 				fmt.Fprintf(os.Stderr, fmt.Sprintf("%s for %s\n", err, ds.Name))
 				continue

--- a/do-restore.go
+++ b/do-restore.go
@@ -95,14 +95,44 @@ func restoreDashboards(cmd *command) {
 }
 
 func restoreDatasources(cmd *command, datasources map[string]bool) {
+	var (
+		//allDatasources []sdk.Datasource
+		rawDS          []byte
+		err            error
+	)
+
+	for _, filename := range cmd.filenames {
+		if strings.HasSuffix(filename, "db.json") {
+			if rawDS, err = ioutil.ReadFile(filename); err != nil {
+				fmt.Fprintf(os.Stderr, "error on read %s", filename)
+				continue
+			}
+
+			// TODO add db match filters
+
+			if err = cmd.grafana.SetRawDashboard(rawDS); err != nil {
+				fmt.Fprintf(os.Stderr, "error on importing dashboard from %s", filename)
+				continue
+			}
+			if cmd.verbose {
+				fmt.Printf("Dashboard restored from %s.\n", filename)
+			}
+		} else {
+			if cmd.verbose {
+				fmt.Fprintf(os.Stderr, "File %s does not appear to be a dashboard: Skipping file.", filename)
+			}
+
+		}
+	}
+
 	if cmd.verbose {
-		fmt.Fprint(os.Stderr, "Restoring datasources not yet implemented!")
+		fmt.Fprintln(os.Stderr, "Restoring datasources not yet implemented!")
 	}
 }
 
 func restoreUsers(cmd *command) {
 	if cmd.verbose {
-		fmt.Fprint(os.Stderr, "Restoring users not yet implemented!")
+		fmt.Fprintln(os.Stderr, "Restoring users not yet implemented!")
 	}
 }
 

--- a/do-restore.go
+++ b/do-restore.go
@@ -19,12 +19,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 	"regexp"
-	"encoding/json"
+	"strings"
+
 	"github.com/grafana-tools/sdk"
 )
 

--- a/do-restore.go
+++ b/do-restore.go
@@ -28,18 +28,19 @@ import (
 	"github.com/grafana-tools/sdk"
 )
 
-
+// Triggers a restore.
 func doRestore(opts ...option) {
 	var (
 		cmd      = initCommand(opts...)
-		//rawBoard []byte
-		//err      error
 	)
 
-	// A heirarchal restore probably isn't feasable until we get better about parsing the JSON. There isn't
-	// going to be a guarantee that the datasource filename is exactly what we expect.
+	// TODO: apply-to auto doesn't make much sense in the context of restore yet.
+	// An actual heirarchal restore probably isn't feasable until we get better about parsing the JSON.
+	// There isn't going to be a guarantee that the datasource filename is exactly what we expect.
 	if cmd.applyHierarchically {
 		restoreDashboards(cmd)
+		restoreDatasources(cmd)
+		restoreUsers(cmd)
 		return
 	}
 	if cmd.applyForBoards {
@@ -84,25 +85,22 @@ func restoreDashboards(cmd *command) {
 			if cmd.verbose {
 				fmt.Printf("Dashboard restored from %s.\n", filename)
 			}
-		} else {
-			if cmd.verbose {
-				fmt.Fprintf(os.Stderr, "File %s does not appear to be a dashboard: Skipping file.", filename)
-			}
-
-		}
+		} //else {
+		//	if cmd.verbose {
+		//		fmt.Fprintf(os.Stderr, "File %s does not appear to be a dashboard: Skipping file.", filename)
+		//	}
+		//
+		//}
 	}
 
-
 	if cmd.applyHierarchically {
-		//restoreDatasources(cmd, datasources)
 		restoreDatasources(cmd)
 	}
 }
 
+// Restores all datasource files. Currently those are files that match the format .*.ds.([0-9]+).json.
 func restoreDatasources(cmd *command) {
-//func restoreDatasources(cmd *command, datasources map[string]bool) {
 	var (
-		//allDatasources []sdk.Datasource
 		rawDS          []byte
 		err            error
 	)
@@ -116,20 +114,11 @@ func restoreDatasources(cmd *command) {
 				continue
 			}
 
-			// TODO: Create a dashboard object and then POST or PUT it to the grafana server.
-			// Will probably want to either just PUT it or check if it exists depending upon how the API reacts.
-
-
 			// TODO: most of this should probably be pushed upstream into grafana SDK in a CreateRawDatasource function
-
-			// From SetRawDashboard
+			// Stolen from SetRawDashboard
 			var (
-				//rawResp []byte
 				resp    sdk.StatusMessage
-				//code    int
 				err     error
-				//buf     bytes.Buffer
-				//plain   = make(map[string]interface{})
 				plain   sdk.Datasource
 			)
 
@@ -138,79 +127,33 @@ func restoreDatasources(cmd *command) {
 				continue
 			}
 
-			rawBoardNew, _ := json.Marshal(plain)
-
-			if cmd.verbose {
-				fmt.Printf("Datasource looks like:\n%s.\n", rawBoardNew)
-			}
-
+			// TODO: See if there's a benefit to using CreateDatasource instead of UpdateDatasource
 			//resp, err = cmd.grafana.CreateDatasource(plain)
 			resp, err = cmd.grafana.UpdateDatasource(plain)
 
-
-			fmt.Fprintf(os.Stderr, "Response:\n")
-
-			if resp.ID != nil {
-				fmt.Fprintf(os.Stderr, "\tID: %d\n", resp.ID)
-			}
-			if resp.Message != nil {
-				fmt.Fprintf(os.Stderr, "\tMessage: %s\n", *resp.Message)
-			}
-
-			if resp.Slug != nil {
-				fmt.Fprintf(os.Stderr, "\tSlug: %s\n", resp.Slug)
-			}
-
-			if resp.Version != nil {
-				fmt.Fprintf(os.Stderr, "\tVersion: %d\n", resp.Version)
-			}
-
-			if resp.Status != nil {
-				fmt.Fprintf(os.Stderr, "\tStatus: %s\n", resp.Status)
-			}
-
-			//ID      *uint   `json:"id"`
-			//Message *string `json:"message"`
-			//Slug    *string `json:"slug"`
-			//Version *int    `json:"version"`
-			//Status  *string `json:"resp"`
-
 			if err != nil {
-				//if err = cmd.grafana.SetRawDashboard(rawBoard); err != nil {
-				fmt.Fprintf(os.Stderr, "error on importing datasource from %s\n", filename)
+				fmt.Fprintf(os.Stderr, "Error importing datasource from %s: %s\n", filename, err)
+				continue
+			}
+			if *resp.Message != "Datasource updated" {
+				fmt.Fprintf(os.Stderr, "Error importing datasource from %s: %s\n", filename, *resp.Message)
 				continue
 			}
 			if cmd.verbose {
 				fmt.Printf("Datasource restored from %s.\n", filename)
 			}
-		} else {
-			if cmd.verbose {
-				fmt.Fprintf(os.Stderr, "File %s does not appear to be a datasource: Skipping file.\n", filename)
-			}
-
-		}
+		} //else {
+		//	if cmd.verbose {
+		//		fmt.Fprintf(os.Stderr, "File %s does not appear to be a datasource: Skipping file.\n", filename)
+		//	}
+		//
+		//}
 	}
 }
 
+// Not yet implemented.
 func restoreUsers(cmd *command) {
 	if cmd.verbose {
 		fmt.Fprintln(os.Stderr, "Restoring users not yet implemented!")
 	}
 }
-
-
-
-
-// Extracts a map of datasources used by a dashboard. This function currently exists inside of do-backup
-// and is here because I have to figure out how to use it when doing a restore then if I use the exact
-// function probably move it to a common library.
-//func extractDatasources(datasources map[string]bool, board sdk.Board) {
-//	for _, row := range board.Rows {
-//		for _, panel := range row.Panels {
-//			if panel.Datasource != nil {
-//				datasources[*panel.Datasource] = true
-//				fmt.Println(slug.Make(*panel.Datasource))
-//			}
-//		}
-//	}
-//}

--- a/main.go
+++ b/main.go
@@ -96,21 +96,27 @@ func main() {
 	case "backup":
 		// TODO fix logic accordingly with apply-for
 		doBackup(serverInstance, applyFor, matchDashboard)
+		fmt.Println("Backup Complete.")
 	case "restore":
 		// TODO fix logic accordingly with apply-for
 		doRestore(serverInstance, applyFor, matchFilename)
+		fmt.Println("Restore Complete.")
 	case "ls":
 		// TODO fix logic accordingly with apply-for
 		doObjectList(serverInstance, applyFor, matchDashboard)
+		fmt.Println("ls Complete.")
 	case "ls-files":
 		// TODO merge this command with ls
 		doFileList(matchFilename, applyFor, matchDashboard)
+		fmt.Println("ls-files Complete.")
 	case "config-set":
 		// TBD
 		// doConfigSet()
+		fmt.Println("Command config-set not yet implemented.")
 	case "config-get":
 		// TBD
 		// doConfigGet()
+		fmt.Println("Command config-get not yet implemented.")
 	default:
 		fmt.Fprintf(os.Stderr, fmt.Sprintf("unknown command: %s\n\n", args[0]))
 		printUsage()

--- a/main.go
+++ b/main.go
@@ -96,27 +96,23 @@ func main() {
 	case "backup":
 		// TODO fix logic accordingly with apply-for
 		doBackup(serverInstance, applyFor, matchDashboard)
-		fmt.Println("Backup Complete.")
 	case "restore":
 		// TODO fix logic accordingly with apply-for
 		doRestore(serverInstance, applyFor, matchFilename)
-		fmt.Println("Restore Complete.")
 	case "ls":
 		// TODO fix logic accordingly with apply-for
 		doObjectList(serverInstance, applyFor, matchDashboard)
-		fmt.Println("ls Complete.")
 	case "ls-files":
 		// TODO merge this command with ls
 		doFileList(matchFilename, applyFor, matchDashboard)
-		fmt.Println("ls-files Complete.")
 	case "config-set":
 		// TBD
 		// doConfigSet()
-		fmt.Println("Command config-set not yet implemented.")
+		fmt.Fprintln(os.Stderr, "Command config-set not yet implemented!")
 	case "config-get":
 		// TBD
 		// doConfigGet()
-		fmt.Println("Command config-get not yet implemented.")
+		fmt.Fprintln(os.Stderr, "Command config-get not yet implemented!")
 	default:
 		fmt.Fprintf(os.Stderr, fmt.Sprintf("unknown command: %s\n\n", args[0]))
 		printUsage()


### PR DESCRIPTION
Added a filter so that we don't try and import data sources as dashboards (based entirely on filename)

Working restoration of datasource types. Similar filter based on file name. 

Nothing for users yet.

I am not 100% thrilled with the way I've implemented some of the functionality so I'm not really expecting this PR to be accepted as is but looking for input on it.

fixes issue #5 